### PR TITLE
added ability to ignore a file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,6 @@ runnable:
 
 curls:
 	@echo "scripts will be executed as listed below"
-	find . -type f -iname "*.sh"
+	find . -type f -iname "*.sh" ! -iname 'bootstrap.sh'
 	@echo ""
-	find . -type f -iname "*.sh" -exec bash {} \;
+	find . -type f -iname "*.sh" ! -iname 'bootstrap.sh' -exec bash {} \;


### PR DESCRIPTION
The file is `bootstrap.sh`. It already does it's job when `make` was typed, so, there is no need for it to be repeat