### PR TITLE
added ability to ignore a file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,6 @@ runnable:
 
 curls:
 	@echo "scripts will be executed as listed below"
-	find . -type f -iname "*.sh"
+	find . -type f -iname "*.sh" ! -iname 'bootstrap.sh'
 	@echo ""
-	find . -type f -iname "*.sh" -exec bash {} \;
+	find . -type f -iname "*.sh" ! -iname 'bootstrap.sh' -exec bash {} \;


### PR DESCRIPTION
The file `bootstrap.sh` was already called during the typing of `make`. Allowing it to run again was redundant.